### PR TITLE
Fixed ESPHome 2024.6.0 breaking change where OTA requires platform

### DIFF
--- a/firmware/stock.yaml
+++ b/firmware/stock.yaml
@@ -33,7 +33,8 @@ web_server:
   js_url: "https://upsy-desky.tjhorner.dev/esphome-webserver/www.js"
 
 ota:
-  password: ""
+  - platform: esphome
+    password: ""
 
 dashboard_import:
   package_import_url: github://tjhorner/upsy-desky/firmware/stock.yaml@v3.0.0


### PR DESCRIPTION
The ESPHome OTA component has a breaking change in 2024.6.0 where the platform needs to be defined https://esphome.io/changelog/2024.6.0.html#ota-platforms